### PR TITLE
Issue 132, switch from User/Weblog to Username/WeblogId where useful.

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/business/UserManager.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/UserManager.java
@@ -183,9 +183,9 @@ public interface UserManager {
     
     
     /**
-     * Grant user specific WeblogRole for a weblog.  Optimized to use IDs
-     * instead of actual User and Weblog objects, as the latter are not always
-     * available without an additional DB call.
+     * Grant user specific WeblogRole for a weblog.  Optimized to use unique identifiers
+     * instead of User and Weblog objects, as the latter not always available without an
+     * additional DB call.
      *
      * @param userName  Username to grant weblog role to
      * @param weblogId  Weblog Id being granted access to
@@ -226,7 +226,9 @@ public interface UserManager {
 
     
     /**
-     * Revoke from user his WeblogRole for a given weblog.
+     * Revoke from user his WeblogRole for a given weblog.  Optimized to use unique identifiers
+     * instead of User and Weblog objects, as the latter not always available without an
+     * additional DB call.
      * @param userName  Username to remove WeblogRole from
      * @param weblogId  Weblog ID to revoke WeblogRole from
      */


### PR DESCRIPTION
#132 

Only two places updated (however in previous PR attached to the issue, updating comments alone here) providing minor benefit.  Largely unnecessary to do to other User-taking UserManager methods due to User objects already being cached by EclipseLink eliminating need for extra DB query anyway.  The two methods updated are those for which it's more probable the User object was never queried and hence cached to begin with. 