### PR TITLE
Issue 732: Don't replace apostrophes with a space when generating anc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Welcome to TightBlog! This project started off in May 2015 as a fork of the Apache Roller project, of which I contributed for about 2 1/2 years 
-before deciding to go my own way due to increasingly differing architectural goals.  As of 4 June 2017, <a href="https://github.com/gmazza/tightblog/releases">Release 2.0</a> is available.
+before deciding to go my own way due to increasingly differing architectural goals.  As of 23 July 2017, <a href="https://github.com/gmazza/tightblog/releases">Release 2.0.1</a> is available.
 
 TightBlog strives to be the mathematically cleanest and simplest implementation of a Java based blog server, suitable either for direct use or
 incorporation, as an Apache-licensed open source project, into larger projects.  Specifically, its goal is to satisfy all the needs of 80% of bloggers while
@@ -12,11 +12,11 @@ This more realistic goal--along with adopting the Spring framework, REST, Angula
 |Apache Roller 5.1.2|1 Mar 2015|33|493|96|95.7K|
 |TightBlog 1.0|17 July 2016|17|187|55|48.5K|
 |TightBlog 2.0|4 June 2017|14|151|37|43.7K|
-|TightBlog 2.0.1|?|13|146|37|42.4K|
+|TightBlog 2.0.1|23 July 2017|13|146|37|42.4K|
 
 (Lines of code based on <a href="https://www.openhub.net/p/tightblog">OpenHub</a> stats.) 
 
-Only increases with TightBlog are about 20 or so new JavaScript files added, due to TightBlog's increased emphasis on browser-side processing.
+However, TightBlog has more JavaScript files due to its emphasis on browser-side processing.
 
 In addition to the cleanout of old functionality some new features have been added:
 
@@ -24,8 +24,9 @@ In addition to the cleanout of old functionality some new features have been add
 * Blog entries have a "notes" field for the blogger to store anything helpful in maintaining the article.
 * There is a new tag management screen allowing for renaming, merging, and deleting tags attached to blog entries, as well as adding a new tag to all articles already having a given tag.
 * A new "search.enabled" setting has been added to static configuration allowing for shutting off the Lucene indexer used for blog searching, useful in saving processing/space for when you're relying on third party indexing tools like Google Custom Search instead.
+* Commenters who request "notify me" to receive emails of future comments for a particular blog entry now receive a link at the bottom of the email to shut off future notifications
 
-Check <a href="https://web-gmazza.rhcloud.com/blog/category/Blogs+%26+Wikis">my blog</a> for recent status updates.
+Check <a href="https://glenmazza.net/blog">my blog</a> for recent status updates.
 
 The top-level TightBlog directory consists of the following folders:
 
@@ -44,7 +45,7 @@ To build the application (app/target/tightblog.war) with Maven and Java 8:
 It's *very* quick and simple to try out TightBlog locally, to determine if this is a product you would like to blog with
 before proceeding with an actual install.  After building the distribution via `mvn clean install`, navigate to the `app` folder and run `mvn jetty:run`,
 and view http://localhost:8080/tightblog from a browser.  From there you can register an account, create a sample blog and some entries,
-create and view comments, modify templates, etc., etc., everything you can do with production TightBlog.  Each time it is run,
+create and view comments, modify templates, etc., everything you can do with production TightBlog.  Each time it is run,
 "mvn jetty:run" creates a new in-memory temporary database that exists until you Ctrl-Z out of the terminal window running this command.
 
 For actual installations on Tomcat or other servlet container, please read the <a href="https://github.com/gmazza/tightblog/wiki">Install pages</a> on the TightBlog Wiki.

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.tightblog</groupId>
         <artifactId>tightblog-project</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app/src/main/java/org/tightblog/util/Utilities.java
+++ b/app/src/main/java/org/tightblog/util/Utilities.java
@@ -153,6 +153,7 @@ public class Utilities {
 
     /**
      * Replaces occurrences of non-alphanumeric characters with a supplied char.
+     * Exception: apostrophes are skipped
      */
     public static String replaceNonAlphanumeric(String str, char subst) {
         StringBuilder ret = new StringBuilder(str.length());
@@ -160,7 +161,7 @@ public class Utilities {
         for (char aChar : testChars) {
             if (Character.isLetterOrDigit(aChar)) {
                 ret.append(aChar);
-            } else {
+            } else if (aChar != '\'') {
                 ret.append(subst);
             }
         }

--- a/app/src/main/resources/tightblog.properties
+++ b/app/src/main/resources/tightblog.properties
@@ -147,13 +147,13 @@ weblogger.revision=${buildNumber}
 # when a new release has a new DB migration script (indicating a changed DB).
 tightblog.database.expected.version=200
 
-# list of links to include in root bookmark folder of each new blog
+# default links to include in blogroll of each new blog
 # format is like so: linktitle2|linkurl2,linktitle2|linkurl2,linktitle3|linkurl3
 newuser.blogroll=\
-Apache Software Foundation|http://apache.org,\
-TightBlog|https://github.com/gmazza/tightblog
+TightBlog|https://github.com/gmazza/tightblog,\
+InfoQ|https://www.infoq.com/
 
-# comma-separated list of top-level categories to be created in each new weblog
+# comma-separated list of default categories to be created in each new weblog
 newuser.categories=Technology,Finance,General
 
 # maximum allowed number of blog entries per page (can be configured lower for each

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.tightblog</groupId>
         <artifactId>tightblog-project</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tightblog</groupId>
     <artifactId>tightblog-project</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
 
     <prerequisites>


### PR DESCRIPTION
…hor URLs

For blog entry title of "bob's trip", instead of bob-s-trip as the entry's anchor, use bobs-trip